### PR TITLE
fix: Fix EVM Transaction Queue Processing - MEED-6897 - Meeds-io/MIPs#118

### DIFF
--- a/gamification-evm-services/src/main/java/io/meeds/evm/gamification/rest/TokensController.java
+++ b/gamification-evm-services/src/main/java/io/meeds/evm/gamification/rest/TokensController.java
@@ -9,8 +9,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
-import java.io.IOException;
-
 @RestController
 @RequestMapping("/gamification/connectors/evm/tokens")
 public class TokensController {
@@ -23,7 +21,8 @@ public class TokensController {
   @ApiResponse(responseCode = "200", description = "Request fulfilled")
   @ApiResponse(responseCode = "404", description = "Not found")
   @ApiResponse(responseCode = "503", description = "Service unavailable")
-  public ERC20Token getERC20Token(@RequestParam(name = "contractAddress")
+  public ERC20Token getERC20Token(
+                                  @RequestParam(name = "contractAddress")
                                   String contractAddress,
                                   @RequestParam(name = "blockchainNetwork")
                                   String blockchainNetwork) {
@@ -32,11 +31,7 @@ public class TokensController {
     } else if (blockchainNetwork == null) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Network url is missing");
     }
-    try {
-      return blockchainService.getERC20TokenDetails(contractAddress, blockchainNetwork);
-    } catch (IOException e) {
-      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "ERC20 doesn't exist");
-    }
+    return blockchainService.getERC20TokenDetails(contractAddress, blockchainNetwork);
   }
 
 }

--- a/gamification-evm-services/src/main/java/io/meeds/evm/gamification/scheduling/task/ERC20TransferTask.java
+++ b/gamification-evm-services/src/main/java/io/meeds/evm/gamification/scheduling/task/ERC20TransferTask.java
@@ -15,10 +15,8 @@
  */
 package io.meeds.evm.gamification.scheduling.task;
 
-import java.math.BigInteger;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import io.meeds.common.ContainerTransactional;
 import io.meeds.evm.gamification.model.TokenTransferEvent;
@@ -31,7 +29,8 @@ import io.meeds.evm.gamification.service.EvmTriggerService;
 import io.meeds.gamification.model.RuleDTO;
 import io.meeds.gamification.model.filter.RuleFilter;
 import io.meeds.gamification.service.RuleService;
-import org.apache.commons.collections.CollectionUtils;
+
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.commons.api.settings.SettingService;
 import org.exoplatform.commons.api.settings.data.Context;
@@ -69,11 +68,10 @@ public class ERC20TransferTask {
   @ContainerTransactional
   @Scheduled(cron = "0 * * * * *")
   public synchronized void listenTokenTransfer() {
-    LOG.info("Start listening erc20 token transfers");
     try {
-
       List<RuleDTO> filteredRules = getFilteredEVMRules();
       if (CollectionUtils.isNotEmpty(filteredRules)) {
+        LOG.info("Start listening erc20 token transfers for {} configured rules", filteredRules.size());
         filteredRules.forEach(rule -> {
           String trigger = rule.getEvent().getTrigger();
           String blockchainNetwork = rule.getEvent().getProperties().get(Utils.BLOCKCHAIN_NETWORK);
@@ -91,7 +89,7 @@ public class ERC20TransferTask {
                                                                                               lastBlock,
                                                                                               contractAddress,
                                                                                               blockchainNetwork);
-          if (!CollectionUtils.isEmpty(events)) {
+          if (CollectionUtils.isNotEmpty(events)) {
             events.forEach(event -> {
               try {
                 EvmTrigger evmTrigger = new EvmTrigger();
@@ -117,8 +115,8 @@ public class ERC20TransferTask {
           }
           saveLastCheckedBlock(lastBlock, contractAddress, networkId, trigger);
         });
+        LOG.info("End listening erc20 token transfers");
       }
-      LOG.info("End listening erc20 token transfers");
     } catch (Exception e) {
       LOG.error("An error occurred while listening erc20 token transfers", e);
     }

--- a/gamification-evm-services/src/main/java/io/meeds/evm/gamification/service/EvmTriggerService.java
+++ b/gamification-evm-services/src/main/java/io/meeds/evm/gamification/service/EvmTriggerService.java
@@ -29,7 +29,6 @@ import jakarta.annotation.PreDestroy;
 import org.exoplatform.wallet.service.WalletAccountService;
 import org.exoplatform.wallet.model.Wallet;
 import io.meeds.gamification.model.EventDTO;
-import io.meeds.gamification.service.ConnectorService;
 import io.meeds.gamification.service.EventService;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -51,9 +50,6 @@ public class EvmTriggerService {
   public static final String GAMIFICATION_GENERIC_EVENT = "exo.gamification.generic.action";
 
   @Autowired
-  private ConnectorService connectorService;
-
-  @Autowired
   private IdentityManager identityManager;
 
   @Autowired
@@ -67,18 +63,8 @@ public class EvmTriggerService {
 
   private ExecutorService executorService;
 
-  public EvmTriggerService(ConnectorService connectorService,
-                               IdentityManager identityManager,
-                               ListenerService listenerService,
-                               EventService eventService) {
-    this.connectorService = connectorService;
-    this.identityManager = identityManager;
-    this.listenerService = listenerService;
-    this.eventService = eventService;
-  }
-
   @PostConstruct
-  public void initialize() {
+  public void init() {
     QueuedThreadPool threadFactory = new QueuedThreadPool(5, 1, 1);
     threadFactory.setName("Gamification - Evm connector");
     executorService = Executors.newCachedThreadPool(threadFactory);


### PR DESCRIPTION
Prior to this change, when an error happens while parsing transfer events, the list of all transfer events processing is stopped as well. This change will attempt to warn about detected Transfer Event incompatibility with ERC20 specification and will just continue the processing of the list of events instead of blocking the execution.