### PR TITLE
feat: Improve Log Verbosity when Blockchain Connection Fails

### DIFF
--- a/gamification-evm-services/src/main/java/io/meeds/evm/gamification/service/EvmBlockchainService.java
+++ b/gamification-evm-services/src/main/java/io/meeds/evm/gamification/service/EvmBlockchainService.java
@@ -198,7 +198,10 @@ public class EvmBlockchainService {
         return "ERC-20";
       }
     } catch (Exception e) {
-      LOG.error("Error  when detecting token type", e);
+      LOG.debug("Error when detecting token type of contract '{}' on blockchain networdk '{}'",
+                contractAddress,
+                blockchainNetwork,
+                e);
     }
     return "Unknown type token";
   }


### PR DESCRIPTION
Prior to this change, when a Blockchain connection error happens during Server Runtime, an error is logged when attempting to detect the Token Type without being thrown to upper layer. This change makes the log as a development log entry instead of using error log level which should be used to indicates that the operation has been interrupted.